### PR TITLE
test: add vertical pricebook tests when R is 1.01

### DIFF
--- a/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
@@ -743,4 +743,31 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
         }
         _checkTakeOrders(Constants.ASK, type(uint16).max, expectedTakeOrders, 0);
     }
+
+    function testLimitBidWithInvalidPriceIndexWithR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE, 101 * 10**16);
+
+        uint64 rawAmount = 3;
+        uint16 maxPriceIndex = market.maxPriceIndex();
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.INVALID_INDEX));
+        market.limitOrder(Constants.USER_A, maxPriceIndex + 1, rawAmount, 0, 1, new bytes(0)); // bid
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.INVALID_INDEX));
+        market.limitOrder(Constants.USER_A, maxPriceIndex + 1, rawAmount, 0, 3, new bytes(0)); // bid + posyOnly
+    }
+
+    function testLimitAskWithInvalidPriceIndexWithR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE, 101 * 10**16);
+
+        uint64 rawAmount = 3;
+        uint16 maxPriceIndex = market.maxPriceIndex();
+
+        uint256 baseAmount = market.rawToBase(rawAmount, maxPriceIndex, true);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.INVALID_INDEX));
+        market.limitOrder(Constants.USER_A, maxPriceIndex + 1, 0, baseAmount, 0, new bytes(0)); // ask
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.INVALID_INDEX));
+        market.limitOrder(Constants.USER_A, maxPriceIndex + 1, 0, baseAmount, 2, new bytes(0)); // ask + posyOnly
+    }
 }

--- a/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
@@ -757,12 +757,13 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
                 Constants.USER_A,
                 priceIndex,
                 0,
-                1, // baseAmount
+                3 * 10**7, // baseAmount
                 0,
                 new bytes(0)
             );
-            // expectedRawAmount: price * _basePrecisionComplement / _quotePrecisionComplement * PRICE_PRECISION * unitQuote
-            uint256 expectedRawAmount = market.indexToPrice(priceIndex) / (10**12 * 10**18 * 10**4);
+            // expectedRawAmount: price * baseAmount * _basePrecisionComplement / _quotePrecisionComplement * PRICE_PRECISION * unitQuote
+            uint256 expectedRawAmount = (market.indexToPrice(priceIndex) * 3 * 10**7 * 10**0) /
+                (10**12 * 10**18 * 10**4);
             expectedTakeOrders[i] = Order({rawAmount: uint64(expectedRawAmount), priceIndex: priceIndex});
             priceIndex -= 128;
         }

--- a/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
@@ -761,9 +761,9 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
                 0,
                 new bytes(0)
             );
-            // expectedRawAmount: price * baseAmount * _basePrecisionComplement / _quotePrecisionComplement * PRICE_PRECISION * unitQuote
+            // expectedRawAmount: price * baseAmount * _basePrecisionComplement / quoteUnit * _quotePrecisionComplement * PRICE_PRECISION
             uint256 expectedRawAmount = (market.indexToPrice(priceIndex) * 3 * 10**7 * 10**0) /
-                (10**12 * 10**18 * 10**4);
+                (10**4 * 10**12 * 10**18);
             expectedTakeOrders[i] = Order({rawAmount: uint64(expectedRawAmount), priceIndex: priceIndex});
             priceIndex -= 128;
         }

--- a/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/LimitOrder.t.sol
@@ -684,7 +684,7 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
         // Takes
         uint16 priceIndex = 0;
         uint64 rawAmount = 3;
-        // To prevent too large price : 313 * 128 = 40064
+
         Order[] memory expectedTakeOrders = new Order[](313);
         for (uint16 i = 0; i < 313; i++) {
             _checkMakeOrder(Constants.BID, rawAmount, priceIndex);
@@ -700,7 +700,7 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
         // Takes
         uint16 priceIndex = 0;
         uint64 rawAmount = 3;
-        // To prevent too large price : 313 * 128 = 40064
+
         Order[] memory expectedTakeOrders = new Order[](313);
         for (uint16 i = 0; i < 313; i++) {
             _checkMakeOrder(Constants.ASK, rawAmount, priceIndex);
@@ -750,11 +750,20 @@ contract LimitOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, Mo
         }
         _checkTakeOrders(Constants.ASK, market.maxPriceIndex(), expectedTakeOrders, 0);
 
-        expectedTakeOrders = new Order[](34);
+        expectedTakeOrders = new Order[](21);
         priceIndex = market.maxPriceIndex();
-        for (uint16 i = 0; i < 34; i++) {
-            _checkMakeOrder(Constants.ASK, rawAmount, priceIndex);
-            expectedTakeOrders[i] = Order({rawAmount: rawAmount, priceIndex: priceIndex});
+        for (uint16 i = 0; i < 21; i++) {
+            market.limitOrder(
+                Constants.USER_A,
+                priceIndex,
+                0,
+                1, // baseAmount
+                0,
+                new bytes(0)
+            );
+            // expectedRawAmount: price * _basePrecisionComplement / _quotePrecisionComplement * PRICE_PRECISION * unitQuote
+            uint256 expectedRawAmount = market.indexToPrice(priceIndex) / (10**12 * 10**18 * 10**4);
+            expectedTakeOrders[i] = Order({rawAmount: uint64(expectedRawAmount), priceIndex: priceIndex});
             priceIndex -= 128;
         }
         _checkTakeOrders(Constants.ASK, market.maxPriceIndex(), expectedTakeOrders, 0);

--- a/test/foundry/OrderBook/integration/GeometricMarket/MarketOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/MarketOrder.t.sol
@@ -856,4 +856,35 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         }
         _checkTakeOrders(Constants.ASK, type(uint16).max, rawAmount * 313, 0, expectedTakeOrders);
     }
+
+    function testMarketBidWithInvalidPriceIndexWithR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE, 101 * 10**16);
+
+        uint64 rawAmount = 3;
+        uint16 maxPriceIndex = market.maxPriceIndex();
+        market.limitOrder(
+            Constants.USER_A,
+            maxPriceIndex,
+            0,
+            market.rawToBase(rawAmount, maxPriceIndex, true),
+            0,
+            new bytes(0)
+        );
+
+        Order[] memory expectedTakeOrders = new Order[](1);
+        expectedTakeOrders[0] = Order({rawAmount: rawAmount, priceIndex: maxPriceIndex});
+        _checkTakeOrders(Constants.ASK, type(uint16).max, rawAmount, 0, expectedTakeOrders);
+    }
+
+    function testMarketAskWithInvalidPriceIndexWithR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE, 101 * 10**16);
+
+        uint64 rawAmount = 3;
+        uint16 maxPriceIndex = market.maxPriceIndex();
+        market.limitOrder(Constants.USER_A, maxPriceIndex, rawAmount, 0, 1, new bytes(0));
+
+        Order[] memory expectedTakeOrders = new Order[](1);
+        expectedTakeOrders[0] = Order({rawAmount: rawAmount, priceIndex: maxPriceIndex});
+        _checkTakeOrders(Constants.BID, 0, 0, market.rawToBase(rawAmount, maxPriceIndex, true), expectedTakeOrders);
+    }
 }

--- a/test/foundry/OrderBook/integration/GeometricMarket/MarketOrder.t.sol
+++ b/test/foundry/OrderBook/integration/GeometricMarket/MarketOrder.t.sol
@@ -106,6 +106,32 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         baseToken.approve(address(market), type(uint256).max);
     }
 
+    function _createMarket(
+        int24 makerFee,
+        uint24 takerFee,
+        uint128 r
+    ) private {
+        orderToken = new OrderNFT(address(this), address(this));
+        market = new VolatileMarket(
+            address(orderToken),
+            address(quoteToken),
+            address(baseToken),
+            10**4,
+            makerFee,
+            takerFee,
+            address(this),
+            Constants.GEOMETRIC_A,
+            r
+        );
+        orderToken.init("", "", address(market));
+
+        quoteToken.mint(address(this), type(uint128).max);
+        quoteToken.approve(address(market), type(uint256).max);
+
+        baseToken.mint(address(this), type(uint128).max);
+        baseToken.approve(address(market), type(uint256).max);
+    }
+
     function _toArray(OrderKey memory orderKey) private pure returns (OrderKey[] memory) {
         OrderKey[] memory ids = new OrderKey[](1);
         ids[0] = orderKey;
@@ -639,7 +665,7 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         );
     }
 
-    function testVerticalBidOrderFlow() public {
+    function testVerticalBidOrderFlowR1001() public {
         _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE);
 
         // Takes
@@ -664,7 +690,7 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         _checkTakeOrders(Constants.BID, 0, 0, baseAmount, expectedTakeOrders);
     }
 
-    function testVerticalAskOrderFlow() public {
+    function testVerticalAskOrderFlowR1001() public {
         _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE);
 
         // Takes
@@ -687,8 +713,8 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         _checkTakeOrders(Constants.ASK, type(uint16).max, rawAmount * 313, 0, expectedTakeOrders);
     }
 
-    function testVerticalClaimedBidOrderFlow() public {
-        testVerticalBidOrderFlow();
+    function testVerticalClaimedBidOrderFlowR1001() public {
+        testVerticalBidOrderFlowR1001();
 
         // Takes
         uint16 priceIndex = 0;
@@ -712,8 +738,8 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         _checkTakeOrders(Constants.BID, 0, 0, baseAmount, expectedTakeOrders);
     }
 
-    function testVerticalClaimedAskOrderFlow() public {
-        testVerticalAskOrderFlow();
+    function testVerticalClaimedAskOrderFlowR1001() public {
+        testVerticalAskOrderFlowR1001();
 
         // Takes
         uint16 priceIndex = 0;
@@ -721,6 +747,102 @@ contract MarketOrderIntegrationTest is Test, CloberMarketSwapCallbackReceiver, M
         // To prevent too large price : 313 * 128 = 40064
         Order[] memory expectedTakeOrders = new Order[](313);
         for (uint16 i = 0; i < 313; i++) {
+            market.limitOrder{value: Constants.CLAIM_BOUNTY * 1 gwei}(
+                Constants.USER_A,
+                priceIndex,
+                0,
+                market.rawToBase(rawAmount, priceIndex, true),
+                0,
+                new bytes(0)
+            );
+            expectedTakeOrders[i] = Order({rawAmount: rawAmount, priceIndex: priceIndex});
+            priceIndex += 128;
+        }
+        _checkTakeOrders(Constants.ASK, type(uint16).max, rawAmount * 313, 0, expectedTakeOrders);
+    }
+
+    function testVerticalBidOrderFlowR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE, 101 * 10**16);
+
+        // Takes
+        uint16 priceIndex = 0;
+        uint64 rawAmount = 3;
+        uint256 baseAmount = 0;
+        // To prevent too large price : 34 * 128 = 4352
+        Order[] memory expectedTakeOrders = new Order[](34);
+        for (uint16 i = 0; i < 34; i++) {
+            market.limitOrder{value: Constants.CLAIM_BOUNTY * 1 gwei}(
+                Constants.USER_A,
+                priceIndex,
+                rawAmount,
+                0,
+                1,
+                new bytes(0)
+            );
+            expectedTakeOrders[i] = Order({rawAmount: rawAmount, priceIndex: priceIndex});
+            baseAmount += market.rawToBase(rawAmount, priceIndex, true);
+            priceIndex += 128;
+        }
+        _checkTakeOrders(Constants.BID, 0, 0, baseAmount, expectedTakeOrders);
+    }
+
+    function testVerticalAskOrderFlowR101() public {
+        _createMarket(-int24(Constants.MAKE_FEE), Constants.TAKE_FEE);
+
+        // Takes
+        uint16 priceIndex = 0;
+        uint64 rawAmount = 3;
+        // To prevent too large price : 34 * 128 = 4352
+        Order[] memory expectedTakeOrders = new Order[](34);
+        for (uint16 i = 0; i < 34; i++) {
+            market.limitOrder{value: Constants.CLAIM_BOUNTY * 1 gwei}(
+                Constants.USER_A,
+                priceIndex,
+                0,
+                market.rawToBase(rawAmount, priceIndex, true),
+                0,
+                new bytes(0)
+            );
+            expectedTakeOrders[i] = Order({rawAmount: rawAmount, priceIndex: priceIndex});
+            priceIndex += 128;
+        }
+        _checkTakeOrders(Constants.ASK, type(uint16).max, rawAmount * 313, 0, expectedTakeOrders);
+    }
+
+    function testVerticalClaimedBidOrderFlowR101() public {
+        testVerticalBidOrderFlowR101();
+
+        // Takes
+        uint16 priceIndex = 0;
+        uint64 rawAmount = 3;
+        uint256 baseAmount = 0;
+        // To prevent too large price : 34 * 128 = 4352
+        Order[] memory expectedTakeOrders = new Order[](34);
+        for (uint16 i = 0; i < 34; i++) {
+            market.limitOrder{value: Constants.CLAIM_BOUNTY * 1 gwei}(
+                Constants.USER_A,
+                priceIndex,
+                rawAmount,
+                0,
+                1,
+                new bytes(0)
+            );
+            expectedTakeOrders[i] = Order({rawAmount: rawAmount, priceIndex: priceIndex});
+            baseAmount += market.rawToBase(rawAmount, priceIndex, true);
+            priceIndex += 128;
+        }
+        _checkTakeOrders(Constants.BID, 0, 0, baseAmount, expectedTakeOrders);
+    }
+
+    function testVerticalClaimedAskOrderFlowR101() public {
+        testVerticalAskOrderFlowR101();
+
+        // Takes
+        uint16 priceIndex = 0;
+        uint64 rawAmount = 3;
+        // To prevent too large price : 34 * 128 = 4352
+        Order[] memory expectedTakeOrders = new Order[](34);
+        for (uint16 i = 0; i < 34; i++) {
             market.limitOrder{value: Constants.CLAIM_BOUNTY * 1 gwei}(
                 Constants.USER_A,
                 priceIndex,


### PR DESCRIPTION
## Changes Made:

Added tests for vertical pricebook functionality with an R value of 1.01. To prevent excessively large prices, I have set a limit for the priceIndex of 4352.

## Description:

This pull request includes new tests to verify the behavior of the vertical pricebook when using an R value of 1.01. Additionally, I have set a limit for the priceIndex to prevent prices from becoming too large.