### PR TITLE
feat: add `contractURI` for nft collection metadata

### DIFF
--- a/contracts/OrderNFT.sol
+++ b/contracts/OrderNFT.sol
@@ -25,6 +25,7 @@ contract OrderNFT is ERC165, CloberOrderNFT {
     string public override name;
     string public override symbol;
     string public override baseURI;
+    string public override contractURI;
     address public override market;
 
     mapping(address => uint256) private _balances;
@@ -71,6 +72,13 @@ contract OrderNFT is ERC165, CloberOrderNFT {
             revert Errors.CloberError(Errors.ACCESS);
         }
         baseURI = newBaseURI;
+    }
+
+    function changeContractURI(string memory newContractURI) external {
+        if (_getHost() != msg.sender) {
+            revert Errors.CloberError(Errors.ACCESS);
+        }
+        contractURI = newContractURI;
     }
 
     function supportsInterface(bytes4 interfaceId) public view override(ERC165, IERC165) returns (bool) {

--- a/contracts/interfaces/CloberOrderNFT.sol
+++ b/contracts/interfaces/CloberOrderNFT.sol
@@ -16,7 +16,6 @@ interface CloberOrderNFT is IERC721, IERC721Metadata {
 
     /**
      * @notice Returns the contract URI for the metadata of this NFT collection.
-     * https://docs.opensea.io/docs/contract-level-metadata
      * @return The contract URI for the metadata of this NFT collection.
      */
     function contractURI() external view returns (string memory);

--- a/contracts/interfaces/CloberOrderNFT.sol
+++ b/contracts/interfaces/CloberOrderNFT.sol
@@ -15,6 +15,13 @@ interface CloberOrderNFT is IERC721, IERC721Metadata {
     function baseURI() external view returns (string memory);
 
     /**
+     * @notice Returns the contract URI for the metadata of this NFT collection.
+     * https://docs.opensea.io/docs/contract-level-metadata
+     * @return The contract URI for the metadata of this NFT collection.
+     */
+    function contractURI() external view returns (string memory);
+
+    /**
      * @notice Returns the address of the market contract that manages this token.
      * @return The address of the market contract that manages this token.
      */
@@ -44,6 +51,12 @@ interface CloberOrderNFT is IERC721, IERC721Metadata {
      * @param newBaseURI The new base URI for the metadata of this NFT collection.
      */
     function changeBaseURI(string memory newBaseURI) external;
+
+    /**
+     * @notice Changes the contract URI for the metadata of this NFT collection.
+     * @param newContractURI The new contract URI for the metadata of this NFT collection.
+     */
+    function changeContractURI(string memory newContractURI) external;
 
     /**
      * @notice Decodes a token id into an order key.

--- a/test/foundry/OrderNFT/Unit.t.sol
+++ b/test/foundry/OrderNFT/Unit.t.sol
@@ -63,6 +63,17 @@ contract OrderNFTUnitTest is Test {
         orderToken.changeBaseURI("URI");
     }
 
+    function testChangeContractURI() public {
+        orderToken.changeContractURI("URI");
+        assertEq(orderToken.contractURI(), "URI", "URI");
+    }
+
+    function testChangeContractURIAccess() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.ACCESS));
+        vm.prank(address(1));
+        orderToken.changeContractURI("URI");
+    }
+
     function testSupportsInterface() public {
         assertTrue(orderToken.supportsInterface(type(IERC721).interfaceId));
         assertTrue(orderToken.supportsInterface(type(IERC721Metadata).interfaceId));


### PR DESCRIPTION
Create `contractURI` function for [opensea](https://docs.opensea.io/docs/contract-level-metadata)