### PR TITLE
feat: add `registerPreviousMarkets` function to migrate previous markets

### DIFF
--- a/contracts/MarketRouter.sol
+++ b/contracts/MarketRouter.sol
@@ -44,7 +44,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
         bytes calldata data
     ) external payable {
         // check if caller is registered market
-        if (!_previousMarkets[msg.sender] && _factory.getMarketHost(msg.sender) == address(0)) {
+        if (!registeredMarket(msg.sender) && _factory.getMarketHost(msg.sender) == address(0)) {
             revert Errors.CloberError(Errors.ACCESS);
         }
 
@@ -166,6 +166,10 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
     ) external payable checkDeadline(marketOrderParams.deadline) {
         _claim(claimParamsList);
         _marketOrder(marketOrderParams, _ASK);
+    }
+
+    function registeredMarket(address market) public view returns (bool) {
+        return _previousMarkets[market];
     }
 
     function registerMarkets(address[] calldata market) external {

--- a/contracts/MarketRouter.sol
+++ b/contracts/MarketRouter.sol
@@ -23,7 +23,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
 
     CloberMarketFactory private immutable _factory;
 
-    mapping(address => bool) private _previousMarkets;
+    mapping(address => bool) private _registeredMarkets;
 
     modifier checkDeadline(uint64 deadline) {
         if (block.timestamp > deadline) {
@@ -169,7 +169,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
     }
 
     function registeredMarket(address market) public view returns (bool) {
-        return _previousMarkets[market];
+        return _registeredMarkets[market];
     }
 
     function registerMarkets(address[] calldata market) external {
@@ -177,7 +177,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
             revert Errors.CloberError(Errors.ACCESS);
         }
         for (uint256 i = 0; i < market.length; ++i) {
-            _previousMarkets[market[i]] = true;
+            _registeredMarkets[market[i]] = true;
         }
     }
 
@@ -186,7 +186,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
             revert Errors.CloberError(Errors.ACCESS);
         }
         for (uint256 i = 0; i < market.length; ++i) {
-            _previousMarkets[market[i]] = false;
+            _registeredMarkets[market[i]] = false;
         }
     }
 }

--- a/contracts/MarketRouter.sol
+++ b/contracts/MarketRouter.sol
@@ -168,12 +168,21 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
         _marketOrder(marketOrderParams, _ASK);
     }
 
-    function registerPreviousMarkets(address[] calldata market) external {
+    function registerMarkets(address[] calldata market) external {
         if (msg.sender != _factory.owner()) {
             revert Errors.CloberError(Errors.ACCESS);
         }
         for (uint256 i = 0; i < market.length; ++i) {
             _previousMarkets[market[i]] = true;
+        }
+    }
+
+    function unregisterMarkets(address[] calldata market) external {
+        if (msg.sender != _factory.owner()) {
+            revert Errors.CloberError(Errors.ACCESS);
+        }
+        for (uint256 i = 0; i < market.length; ++i) {
+            _previousMarkets[market[i]] = false;
         }
     }
 }

--- a/contracts/MarketRouter.sol
+++ b/contracts/MarketRouter.sol
@@ -44,7 +44,7 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
         bytes calldata data
     ) external payable {
         // check if caller is registered market
-        if (!registeredMarket(msg.sender) && _factory.getMarketHost(msg.sender) == address(0)) {
+        if (!isRegisteredMarket(msg.sender) && _factory.getMarketHost(msg.sender) == address(0)) {
             revert Errors.CloberError(Errors.ACCESS);
         }
 
@@ -168,25 +168,25 @@ contract MarketRouter is CloberMarketSwapCallbackReceiver, CloberRouter {
         _marketOrder(marketOrderParams, _ASK);
     }
 
-    function registeredMarket(address market) public view returns (bool) {
+    function isRegisteredMarket(address market) public view returns (bool) {
         return _registeredMarkets[market];
     }
 
-    function registerMarkets(address[] calldata market) external {
+    function registerMarkets(address[] calldata markets) external {
         if (msg.sender != _factory.owner()) {
             revert Errors.CloberError(Errors.ACCESS);
         }
-        for (uint256 i = 0; i < market.length; ++i) {
-            _registeredMarkets[market[i]] = true;
+        for (uint256 i = 0; i < markets.length; ++i) {
+            _registeredMarkets[markets[i]] = true;
         }
     }
 
-    function unregisterMarkets(address[] calldata market) external {
+    function unregisterMarkets(address[] calldata markets) external {
         if (msg.sender != _factory.owner()) {
             revert Errors.CloberError(Errors.ACCESS);
         }
-        for (uint256 i = 0; i < market.length; ++i) {
-            _registeredMarkets[market[i]] = false;
+        for (uint256 i = 0; i < markets.length; ++i) {
+            _registeredMarkets[markets[i]] = false;
         }
     }
 }

--- a/contracts/interfaces/CloberRouter.sol
+++ b/contracts/interfaces/CloberRouter.sol
@@ -140,4 +140,13 @@ interface CloberRouter {
         ClaimOrderParams[] calldata claimParamsList,
         MarketOrderParams calldata marketOrderParams
     ) external payable;
+
+    // TODO
+    function registerMarkets(address[] calldata market) external;
+
+    // TODO
+    function unregisterMarkets(address[] calldata market) external;
+
+    // TODO
+    function registeredMarket(address market) external view returns (bool);
 }

--- a/contracts/interfaces/CloberRouter.sol
+++ b/contracts/interfaces/CloberRouter.sol
@@ -141,12 +141,21 @@ interface CloberRouter {
         MarketOrderParams calldata marketOrderParams
     ) external payable;
 
-    // TODO
-    function registerMarkets(address[] calldata market) external;
+    /**
+     * @notice Registers markets to be accepted by the router.
+     * @param markets Markets to be registered.
+     */
+    function registerMarkets(address[] calldata markets) external;
 
-    // TODO
-    function unregisterMarkets(address[] calldata market) external;
+    /**
+     * @notice Unregisters markets denying their use by the router.
+     * @param markets Markets to be unregistered.
+     */
+    function unregisterMarkets(address[] calldata markets) external;
 
-    // TODO
-    function registeredMarket(address market) external view returns (bool);
+    /**
+     * @notice Checks if the market is registered.
+     * @param market The market to be checked for registration status.
+     */
+    function isRegisteredMarket(address market) external view returns (bool);
 }

--- a/test/foundry/MarketRouter/Unit.t.sol
+++ b/test/foundry/MarketRouter/Unit.t.sol
@@ -735,6 +735,7 @@ contract MarketRouterUnitTest is Test {
         address[] memory previousMarkets = new address[](1);
         previousMarkets[0] = address(market1);
         newRouter.registerMarkets(previousMarkets);
+        assertEq(newRouter.registeredMarket(address(market1)), true);
 
         CloberRouter.LimitOrderParams memory params = _buildLimitOrderParams(address(market1), 10, 0, POST_ONLY);
         params.deadline = uint64(block.timestamp + 100);
@@ -743,6 +744,8 @@ contract MarketRouterUnitTest is Test {
         newRouter.limitBid{value: uint256(CLAIM_BOUNTY) * 1 gwei}(params);
 
         newRouter.unregisterMarkets(previousMarkets);
+        assertEq(newRouter.registeredMarket(address(market1)), false);
+
         params = _buildLimitOrderParams(address(market1), 10, 0, POST_ONLY);
         params.deadline = uint64(block.timestamp + 100);
         vm.prank(USER);

--- a/test/foundry/MarketRouter/Unit.t.sol
+++ b/test/foundry/MarketRouter/Unit.t.sol
@@ -734,12 +734,20 @@ contract MarketRouterUnitTest is Test {
         MarketRouter newRouter = _deployNewRouter();
         address[] memory previousMarkets = new address[](1);
         previousMarkets[0] = address(market1);
-        newRouter.registerPreviousMarkets(previousMarkets);
+        newRouter.registerMarkets(previousMarkets);
 
         CloberRouter.LimitOrderParams memory params = _buildLimitOrderParams(address(market1), 10, 0, POST_ONLY);
         params.deadline = uint64(block.timestamp + 100);
         vm.prank(USER);
         vm.deal(USER, uint256(CLAIM_BOUNTY) * 1 gwei);
+        newRouter.limitBid{value: uint256(CLAIM_BOUNTY) * 1 gwei}(params);
+
+        newRouter.unregisterMarkets(previousMarkets);
+        params = _buildLimitOrderParams(address(market1), 10, 0, POST_ONLY);
+        params.deadline = uint64(block.timestamp + 100);
+        vm.prank(USER);
+        vm.deal(USER, uint256(CLAIM_BOUNTY) * 1 gwei);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.ACCESS));
         newRouter.limitBid{value: uint256(CLAIM_BOUNTY) * 1 gwei}(params);
     }
 
@@ -749,6 +757,10 @@ contract MarketRouterUnitTest is Test {
 
         vm.prank(USER);
         vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.ACCESS));
-        router.registerPreviousMarkets(previousMarkets);
+        router.registerMarkets(previousMarkets);
+
+        vm.prank(USER);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CloberError.selector, Errors.ACCESS));
+        router.unregisterMarkets(previousMarkets);
     }
 }


### PR DESCRIPTION
### Features
Create `registerPreviousMarkets` function to support migrating previous markets

### Description:
This pull request adds a new function called `registerPreviousMarkets` to the codebase. This function supports migrating previous markets and will help ensure that market data is properly carried over to new versions of the code.